### PR TITLE
Feature: benchmark multiple images

### DIFF
--- a/algorithms/huffman.py
+++ b/algorithms/huffman.py
@@ -80,16 +80,16 @@ def Total_Gain(data, coding):
         count = data.count(symbol)
         # calculate how many bit is required for that symbol in total
         after_compression += count * len(coding[symbol])
-    print("Space usage before compression (in bits):", before_compression)
-    print("Space usage after compression (in bits):",  after_compression)
+    # print("Space usage before compression (in bits):", before_compression)
+    # print("Space usage after compression (in bits):",  after_compression)
 
 
 def compress(data):
     symbol_with_probs = Calculate_Probability(data)
     symbols = symbol_with_probs.keys()
     probabilities = symbol_with_probs.values()
-    print("symbols: ", symbols)
-    print("probabilities: ", probabilities)
+    # print("symbols: ", symbols)
+    # print("probabilities: ", probabilities)
 
     nodes = []
 
@@ -119,7 +119,7 @@ def compress(data):
         nodes.append(newNode)
 
     huffman_encoding = Calculate_Codes(nodes[0])
-    print("symbols with codes", huffman_encoding)
+    # print("symbols with codes", huffman_encoding)
     Total_Gain(data, huffman_encoding)
     encoded_output = Output_Encoded(data, huffman_encoding)
     return encoded_output, nodes[0]

--- a/helper/benchmark.py
+++ b/helper/benchmark.py
@@ -14,9 +14,9 @@ def find_benchmark_images():
     return [*map(str, joined_paths)]
 
 
-def benchmark(algo, results: DataFrame):
+def benchmark(algo, image_path: str, results: DataFrame):
     # TODO: Benchmark more than one image
-    image = Image.open("images/rgb8bit/artificial.ppm")
+    image = Image.open(image_path)
     img_byte_array = io.BytesIO()
     image.save(img_byte_array, format=image.format)
     raw_bytes = img_byte_array.getvalue()
@@ -47,6 +47,7 @@ def benchmark(algo, results: DataFrame):
     result = Series(
         [
             algo.__name__.split(".")[1],
+            image_path,
             compress_end - compress_start,
             decompress_end - decompress_start,
             compression_ratio,

--- a/helper/benchmark.py
+++ b/helper/benchmark.py
@@ -15,7 +15,6 @@ def find_benchmark_images():
 
 
 def benchmark(algo, image_path: str, results: DataFrame):
-    # TODO: Benchmark more than one image
     image = Image.open(image_path)
     img_byte_array = io.BytesIO()
     image.save(img_byte_array, format=image.format)

--- a/helper/constants.py
+++ b/helper/constants.py
@@ -1,8 +1,13 @@
-cols = ["algorithm", "compress_time", "decompress_time", "compression_ratio", "source_entropy", "bits_per_pixel"]
+cols = [
+    "algorithm",
+    "image",
+    "compress_time",
+    "decompress_time",
+    "compression_ratio",
+]
+
 units = {
     "compress_time": "nanoseconds",
     "decompress_time": "nanoseconds",
     "compression_ratio": "raw / compressed bytes",
-    "source_entropy": "TODO", 
-    "bits_per_pixel": "TODO"
 }

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from pandas import DataFrame
 from algorithms import burrows_wheeler, rle, zlib, lzw, huffman
-from helper.benchmark import benchmark
+from helper.benchmark import benchmark, find_benchmark_images
 from helper.constants import cols
 
 # TODO: Add more algorithms through parametrization
@@ -15,9 +15,11 @@ algos = [
 
 def main(out_file="results/benchmarks.csv"):
     results = DataFrame(columns=cols)
+    images = find_benchmark_images()
     for algo in algos:
-        print(f"Running benchmarks for {algo=}...")
-        results = benchmark(algo, results)
+        for image in images:
+            print(f"Running benchmarks for {(algo.__name__.split('.')[1], image)}...")
+            results = benchmark(algo, image, results)
     results.to_csv(out_file)
 
 


### PR DESCRIPTION
Things to take into account with this PR:

* To _clean_ the output when executing the main file, I commented out the Huffman print statements.
  * If you look inside the Huffman code, I saw some functions that already calculate some metrics for Huffman. Perhaps we can re-use those
* I created a helper function that finds all the `pgm` (grayscale) and `ppm` (color / rgb) images using Python Standard Library (`pathlib`).